### PR TITLE
Use mac version from https://github.com/eugene1g/phantomjs

### DIFF
--- a/src/PhantomInstaller/Installer.php
+++ b/src/PhantomInstaller/Installer.php
@@ -162,6 +162,14 @@ class Installer
             $targetName = str_replace('/', '\\', $targetName);
         }
 
+        /**
+         * The folder structure from
+         * https://github.com/eugene1g/phantomjs is different.
+         */
+        if ($os === 'macosx') {
+            $sourceName = str_replace('/bin', '', $sourceName);
+        }
+
         if ($os !== 'unknown') {
             copy($targetDir . $sourceName, $targetName);
             chmod($targetName, 0755);
@@ -250,7 +258,7 @@ class Installer
         }
 
         if ($os === 'macosx') {
-            $url = 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-' . $version . '-macosx.zip';
+            $url = 'https://github.com/eugene1g/phantomjs/releases/download/' . $version . '-bin/phantomjs-' . $version . '-macosx.zip';
         }
 
         # OS unknown


### PR DESCRIPTION
The mac version 2.0.0 from https://github.com/ariya/phantomjs does not
work with OS X Yosemite.

An alternative build has been provided by
https://github.com/eugene1g/phantomjs.

@eugene1g has upstream hos
changes (https://github.com/ariya/phantomjs/pull/12934) and they have
been applied upstream but no release is done from upstream yet.