### PR TITLE
use static to access chmod constant

### DIFF
--- a/src/PhantomInstaller/Installer.php
+++ b/src/PhantomInstaller/Installer.php
@@ -275,7 +275,7 @@ class Installer
 
         if ($os !== 'unknown') {
             copy($targetDir . $sourceName, $targetName);
-            chmod($targetName, self::PHANTOMJS_CHMODE);
+            chmod($targetName, static::PHANTOMJS_CHMODE);
         }
 
         self::dropClassWithPathToInstalledBinary($targetName);


### PR DESCRIPTION
to allow override via extending class like so:

```php
use PhantomInstaller\Installer as BaseInstaller;

class Installer extends BaseInstaller
{
    const PHANTOMJS_CHMODE = 0755;
}
```