### PR TITLE
Catch all Exceptions and display Message on CLI

### DIFF
--- a/src/PhantomInstaller/Installer.php
+++ b/src/PhantomInstaller/Installer.php
@@ -141,6 +141,10 @@ class Installer
                     $version = self::getLowerVersion($version);
                     $io->write('<warning>Retrying the download with a lower version number: "'. $version .'".</warning>');
                 }
+            } catch (\Exception $e) {
+                $message = $e->getMessage();
+                $io->write(PHP_EOL . '<error>While downloading version '. $version. ' the following error accoured: '. $message .'</error>');
+                return false;
             }
         }
     }


### PR DESCRIPTION
Prior the Installer failed silently if something went wrong in the download method. Only the `\Composer\Downloader\TransportException` was catched.

This PR catches all other exceptions and will display the Exception Message as an `<error>` in the console.

Also see #32.