### PR TITLE
Fix TypeError thrown during install

### DIFF
--- a/src/PhantomInstaller/Installer.php
+++ b/src/PhantomInstaller/Installer.php
@@ -204,7 +204,7 @@ class Installer
             $package = $this->createComposerInMemoryPackage($targetDir, $version);
 
             try {
-                $downloadManager->download($package, $targetDir, false);
+                $downloadManager->download($package, $targetDir, null);
                 return true;
             } catch (TransportException $e) {
                 if ($e->getStatusCode() === 404) {


### PR DESCRIPTION
This change solves the problem of a fatal error thrown during the execution of the post-install/update script. Specifically:

```
Fatal error: Uncaught TypeError: Composer\Downloader\DownloadManager::download(): Argument #3 ($prevPackage) must be of type ?Composer\Package\PackageInterface, bool given, called in ...\jakoch\phantomjs-installer\src\PhantomInstaller\Installer.php on line 192 and defined in .../Composer/Downloader/DownloadManager.php:182
```